### PR TITLE
Moving abstracts events functions to virtual to add more flexibility

### DIFF
--- a/.github/workflows/UMVC.Core.yml
+++ b/.github/workflows/UMVC.Core.yml
@@ -26,7 +26,7 @@ jobs:
         run: .\UMVC.Core\packages\OpenCover\4.7.922\tools\OpenCover.Console.exe -register -filter:"+[*]* -[*]*.Templates.* -[*]*.Mock.*" -target:".\UMVC.Core\packages\NUnit.ConsoleRunner\3.11.1\tools\nunit3-console.exe" -targetargs:"/domain:single .\UMVC.Core\Tests\bin\Debug\net461\UMVC.Core.Tests.dll" -output:coverage.xml
 
       - name: Codecov
-        uses: codecov/codecov-action@v1.0.7
+        uses: codecov/codecov-action@v1.0.10
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml

--- a/.github/workflows/UMVC.Editor.Core.release.yml
+++ b/.github/workflows/UMVC.Editor.Core.release.yml
@@ -88,7 +88,7 @@ jobs:
   Test_UMVC_Editor:
     name: Test UMVC.Editor 🧪
     runs-on: ubuntu-latest
-    container: gableroux/unity3d:2019.4.1f1
+    container: gableroux/unity3d:2019.3.13f1
     needs: Build_UMVC_Core
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
 
@@ -128,7 +128,7 @@ jobs:
   Build_UMVC_Editor:
     name: Build UMVC.Editor 🏗️
     runs-on: ubuntu-latest
-    container: gableroux/unity3d:2019.4.1f1
+    container: gableroux/unity3d:2019.3.13f1
     needs: Test_UMVC_Editor
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
 

--- a/.github/workflows/UMVC.Editor.Core.release.yml
+++ b/.github/workflows/UMVC.Editor.Core.release.yml
@@ -29,7 +29,7 @@ jobs:
         run: .\UMVC.Core\packages\OpenCover\4.7.922\tools\OpenCover.Console.exe -register -filter:"+[*]* -[*]*.Templates.* -[*]*.Mock.*" -target:".\UMVC.Core\packages\NUnit.ConsoleRunner\3.11.1\tools\nunit3-console.exe" -targetargs:"/domain:single .\UMVC.Core\Tests\bin\Debug\net461\UMVC.Core.Tests.dll" -output:coverage.xml
 
       - name: Codecov
-        uses: codecov/codecov-action@v1.0.7
+        uses: codecov/codecov-action@v1.0.10
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
@@ -88,7 +88,7 @@ jobs:
   Test_UMVC_Editor:
     name: Test UMVC.Editor 🧪
     runs-on: ubuntu-latest
-    container: gableroux/unity3d:2019.3.13f1
+    container: gableroux/unity3d:2019.4.1f1
     needs: Build_UMVC_Core
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
 
@@ -118,7 +118,7 @@ jobs:
         run: sh .github/workflows/scripts/run-editor-tests.sh
 
       - name: Codecov
-        uses: codecov/codecov-action@v1.0.7
+        uses: codecov/codecov-action@v1.0.10
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./CodeCoverage/UMVC-opencov/EditMode/TestCoverageResults_0000.xml
@@ -128,7 +128,7 @@ jobs:
   Build_UMVC_Editor:
     name: Build UMVC.Editor 🏗️
     runs-on: ubuntu-latest
-    container: gableroux/unity3d:2019.3.13f1
+    container: gableroux/unity3d:2019.4.1f1
     needs: Test_UMVC_Editor
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
 

--- a/.github/workflows/UMVC.Editor.yml
+++ b/.github/workflows/UMVC.Editor.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     name: Test UMVC.Editor 🧪
     runs-on: ubuntu-latest
-    container: gableroux/unity3d:2019.3.13f1
+    container: gableroux/unity3d:2019.4.1f1
 
     steps:
       - name: Wait for build to succeed
@@ -49,7 +49,7 @@ jobs:
         run: sh .github/workflows/scripts/run-editor-tests.sh
         
       - name: Codecov
-        uses: codecov/codecov-action@v1.0.7
+        uses: codecov/codecov-action@v1.0.10
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./CodeCoverage/UMVC-opencov/EditMode/TestCoverageResults_0000.xml

--- a/.github/workflows/UMVC.Editor.yml
+++ b/.github/workflows/UMVC.Editor.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     name: Test UMVC.Editor 🧪
     runs-on: ubuntu-latest
-    container: gableroux/unity3d:2019.4.1f1
+    container: gableroux/unity3d:2019.3.13f1
 
     steps:
       - name: Wait for build to succeed

--- a/MSBuildForUnity.Common.props
+++ b/MSBuildForUnity.Common.props
@@ -23,7 +23,7 @@
     
     <UnityMajorVersion>2019</UnityMajorVersion>
     <UnityMinorVersion>4</UnityMinorVersion>
-    <UnityEditorInstallPath>C:\Program Files\Unity\Hub\Editor\2019.4.1f1\Editor</UnityEditorInstallPath>
+    <UnityEditorInstallPath>C:\Program Files\Unity\Hub\Editor\2019.4.2f1\Editor</UnityEditorInstallPath>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.4.1f1
-m_EditorVersionWithRevision: 2019.4.1f1 (e6c045e14e4e)
+m_EditorVersion: 2019.4.2f1
+m_EditorVersionWithRevision: 2019.4.2f1 (20b4642a3455)

--- a/UMVC.Core/MVC/BaseView.cs
+++ b/UMVC.Core/MVC/BaseView.cs
@@ -24,8 +24,15 @@ namespace UMVC.Core.MVC
             Controller.LateSetup();
         }
 
-        
-        public abstract void OnFieldWillUpdate(string field, object newObject, object oldObject);
-        public abstract void OnFieldDidUpdate(string field, object value);
+
+        public virtual void OnFieldWillUpdate(string field, object newObject, object oldObject)
+        {
+            
+        }
+
+        public virtual void OnFieldDidUpdate(string field, object value)
+        {
+            
+        }
     }
 }

--- a/UMVC.Core/Templates/ViewTemplate.cs
+++ b/UMVC.Core/Templates/ViewTemplate.cs
@@ -34,19 +34,7 @@ namespace UMVC.Core.Templates
             this.Write(this.ToStringHelper.ToStringWithCulture(Model));
             this.Write(", ");
             this.Write(this.ToStringHelper.ToStringWithCulture(Controller));
-            this.Write(@">
-    {
-        public override void OnFieldWillUpdate(string field, object newObject, object oldObject)
-        {
-            
-        }
-
-        public override void OnFieldDidUpdate(string field, object value)
-        {
-            
-        }
-    }
-}");
+            this.Write(">\r\n    {\r\n\r\n    }\r\n}");
             return this.GenerationEnvironment.ToString();
         }
 

--- a/UMVC.Core/Templates/ViewTemplate.tt
+++ b/UMVC.Core/Templates/ViewTemplate.tt
@@ -11,14 +11,6 @@ namespace <#= Namespace #>
 {
     public class <#= ClassName #> : <#= Extends #><<#= Model #>, <#= Controller #>>
     {
-        public override void OnFieldWillUpdate(string field, object newObject, object oldObject)
-        {
-            
-        }
 
-        public override void OnFieldDidUpdate(string field, object value)
-        {
-            
-        }
     }
 }

--- a/UMVC.Core/TestTemplates/ViewTemplateTest.cs
+++ b/UMVC.Core/TestTemplates/ViewTemplateTest.cs
@@ -4,14 +4,6 @@ namespace MyNamespace
 {
     public class TestView : BaseView<Model, TestController>
     {
-        public override void OnFieldWillUpdate(string field, object newObject, object oldObject)
-        {
-            
-        }
 
-        public override void OnFieldDidUpdate(string field, object value)
-        {
-            
-        }
     }
 }


### PR DESCRIPTION
## Changes of targeted release 0.3.0

* Moving abstracts events functions to virtual to add more flexibility
* Updating Github Actions
* Upgrading to Unity 2019.4.1f